### PR TITLE
Implement Display trait & unify TryFrom implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,13 @@ impl std::convert::TryFrom<String> for NonEmptyString {
     }
 }
 
+impl std::fmt::Display for NonEmptyString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -192,4 +199,13 @@ mod tests {
         // `len` is a `String` method.
         assert!(nes.len() > 0);
     }
+    
+    #[test]
+    fn format_test() {
+        let str = NonEmptyString::new("string".to_owned()).unwrap();
+        println!("{}", &str);
+        
+        let _str: String = str.to_string();
+    }
+    
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,19 +115,19 @@ impl NonEmptyString {
     }
 }
 
-impl std::convert::AsRef<str> for NonEmptyString {
+impl AsRef<str> for NonEmptyString {
     fn as_ref(&self) -> &str {
         &self.0
     }
 }
 
-impl std::convert::AsRef<String> for NonEmptyString {
+impl AsRef<String> for NonEmptyString {
     fn as_ref(&self) -> &String {
         &self.0
     }
 }
 
-impl<'s> std::convert::TryFrom<&'s str> for NonEmptyString {
+impl<'s> TryFrom<&'s str> for NonEmptyString {
     type Error = ();
 
     fn try_from(value: &'s str) -> Result<Self, Self::Error> {
@@ -139,7 +139,7 @@ impl<'s> std::convert::TryFrom<&'s str> for NonEmptyString {
     }
 }
 
-impl std::convert::TryFrom<String> for NonEmptyString {
+impl TryFrom<String> for NonEmptyString {
     type Error = String;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
@@ -152,7 +152,6 @@ impl std::fmt::Display for NonEmptyString {
         write!(f, "{}", self.0)
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -198,13 +197,12 @@ mod tests {
         // `len` is a `String` method.
         assert!(nes.len() > 0);
     }
-    
+
     #[test]
     fn format_test() {
         let str = NonEmptyString::new("string".to_owned()).unwrap();
         println!("{}", &str);
-        
+
         let _str: String = str.to_string();
     }
-    
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,14 +128,14 @@ impl AsRef<String> for NonEmptyString {
 }
 
 impl<'s> TryFrom<&'s str> for NonEmptyString {
-    type Error = ();
+    type Error = &'s str;
 
     fn try_from(value: &'s str) -> Result<Self, Self::Error> {
         if value.is_empty() {
-            Err(())
-        } else {
-            Ok(NonEmptyString::new(value.to_owned()).expect("Value is not empty"))
+            return Err(value);
         }
+            
+        Ok(NonEmptyString(value.to_owned()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod test_readme {
     mod something {}
 }
 
+use std::fmt::Display;
 use delegate::delegate;
 
 #[cfg(feature = "serde")]
@@ -147,9 +148,9 @@ impl TryFrom<String> for NonEmptyString {
     }
 }
 
-impl std::fmt::Display for NonEmptyString {
+impl Display for NonEmptyString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        Display::fmt(&self.0, f)
     }
 }
 
@@ -202,7 +203,6 @@ mod tests {
     fn format_test() {
         let str = NonEmptyString::new("string".to_owned()).unwrap();
         println!("{}", &str);
-
-        let _str: String = str.to_string();
+        assert_eq!(String::from("string"), str.to_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,16 +157,15 @@ impl std::fmt::Display for NonEmptyString {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assert_matches::assert_matches;
 
     #[test]
-    fn empty_string_returns_none() {
+    fn empty_string_returns_err() {
         assert_eq!(NonEmptyString::new("".to_owned()), Err("".to_owned()));
     }
 
     #[test]
-    fn non_empty_string_returns_some() {
-        assert_matches!(NonEmptyString::new("string".to_owned()), Ok(_));
+    fn non_empty_string_returns_ok() {
+        assert!(NonEmptyString::new("string".to_owned()).is_ok())
     }
 
     #[test]


### PR DESCRIPTION
Hi. 
First, thanks for this crate.

Now.
* I think its necessary the `NonEmptyString::to_string` method. Because is usefull, and is weird not implement this method in a String wrapper.
* The `TryFrom` implementations are uncongruent. I think this more congruent
```rust
impl TryFrom<String> for NonEmptyString {
    type Error = String;
   ...
}

impl<'s> TryFrom<&'s str> for NonEmptyString {
    type Error = &'s str;
   ...
}
```
that

```rust
impl TryFrom<String> for NonEmptyString {
    type Error = String;
   ...
}

impl<'s> TryFrom<&'s str> for NonEmptyString {
    type Error = ();
   ...
}
```

For the tests, I'm trying to simplify the code 🦀
