### PR TITLE
Specific Error Type: ErrorEmptyString

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ A simple wrapper type for `String`s that ensures that the string inside is not `
 ## Example
 
 ```rust
-use non_empty_string::NonEmptyString;
+use non_empty_string::{NonEmptyString, ErrorEmptyString};
 
 // Constructing it from a normal (non-zero-length) String works fine.
 let s = "A string with a length".to_owned();
 assert!(NonEmptyString::new(s).is_ok());
 
-// But constructing it from a non-zero-length String results in an `Err`, where we get the `String` back that we passed in.
+// But constructing it from a zero-length String results in an `Err`.
 let empty = "".to_owned();
 let result = NonEmptyString::new(empty);
 assert!(result.is_err());
-assert_eq!(result.unwrap_err(), "".to_owned())
+assert_eq!(result.unwrap_err(), ErrorEmptyString);
 
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,15 @@ use std::fmt::Display;
 #[cfg(feature = "serde")]
 mod serde_support;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorEmptyString;
+
+impl Display for ErrorEmptyString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self, f)
+    }
+}
+
 /// A simple String wrapper type, similar to NonZeroUsize and friends.
 /// Guarantees that the String contained inside is not of length 0.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -25,10 +34,10 @@ pub struct NonEmptyString(String);
 #[allow(clippy::len_without_is_empty)] // is_empty would always returns false so it seems a bit silly to have it.
 impl NonEmptyString {
     /// Attempts to create a new NonEmptyString.
-    /// If the given `string` is empty, `Err` is returned, containing the original `String`, `Ok` otherwise.
-    pub fn new(string: String) -> Result<NonEmptyString, String> {
+    /// If the given `string` is empty, `Err` is returned, `Ok` otherwise.
+    pub fn new(string: String) -> Result<NonEmptyString, ErrorEmptyString> {
         if string.is_empty() {
-            Err(string)
+            Err(ErrorEmptyString)
         } else {
             Ok(NonEmptyString(string))
         }
@@ -129,11 +138,11 @@ impl AsRef<String> for NonEmptyString {
 }
 
 impl<'s> TryFrom<&'s str> for NonEmptyString {
-    type Error = &'s str;
+    type Error = ErrorEmptyString;
 
     fn try_from(value: &'s str) -> Result<Self, Self::Error> {
         if value.is_empty() {
-            return Err(value);
+            return Err(ErrorEmptyString);
         }
 
         Ok(NonEmptyString(value.to_owned()))
@@ -141,7 +150,7 @@ impl<'s> TryFrom<&'s str> for NonEmptyString {
 }
 
 impl TryFrom<String> for NonEmptyString {
-    type Error = String;
+    type Error = ErrorEmptyString;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         NonEmptyString::new(value)
@@ -160,7 +169,7 @@ mod tests {
 
     #[test]
     fn empty_string_returns_err() {
-        assert_eq!(NonEmptyString::new("".to_owned()), Err("".to_owned()));
+        assert_eq!(NonEmptyString::new("".to_owned()), Err(ErrorEmptyString));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,10 @@ impl NonEmptyString {
     /// If the given `string` is empty, `Err` is returned, `Ok` otherwise.
     pub fn new(string: String) -> Result<NonEmptyString, ErrorEmptyString> {
         if string.is_empty() {
-            Err(ErrorEmptyString)
-        } else {
-            Ok(NonEmptyString(string))
+            return Err(ErrorEmptyString);
         }
+
+        Ok(NonEmptyString(string))
     }
 
     /// Returns a reference to the contained value.

--- a/src/serde_support.rs
+++ b/src/serde_support.rs
@@ -45,7 +45,8 @@ impl<'de> Visitor<'de> for NonEmptyStringVisitor {
     where
         E: de::Error,
     {
-        NonEmptyString::new(value).map_err(|e| de::Error::invalid_value(Unexpected::Str(&e), &self))
+        NonEmptyString::new(value)
+            .map_err(|_e| de::Error::invalid_value(Unexpected::Str(""), &self))
     }
 }
 


### PR DESCRIPTION
Hello!

I think, return an empty `&str` or empty `String` in Result is not a good idea, especially because this is a library crate. 

Reasons:
* The error can't provide util information.
* Is more complicate do a correct casting from this error

For the last reason, an example using error-kind pattern
```rust

enum ErrorKind {
    EmptyString,
    Other,
    /*...*/
}

struct MyError {
    kind: ErrorKind,
    error:  String
}

impl From<String> for MyError {
    fn from(error: String) -> Self {
        if error.is_empty() { // Is necessary check manually if the error is empty
            return MyError {
                kind: EmptyString,
                error: "Error: zero-value string".to_string(),
            };
        }

        MyError {
            kind: Other,
            error,
        }
    }
}

```
One example with enum error type

```rust
enum MyError {
    EmptyString,
    Unknown(String),
    /*...*/
}

impl From<String> for MyError {
    fn from(error: String) -> Self {
        if error.is_empty() { // Again, is necessary check manually if the error is empty
            return MyError::EmptyString;
        }

        MyError::Unknown(error)
    }
}

```

With `ErrorEmptyString` error type, both cases are covered