### PR TITLE
Implemented macro for compile time non empty string creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "non-empty-string"
-version = "0.2.5"
+name = "patskovn-non-empty-string"
+version = "0.2.6"
 edition = "2021"
-authors = ["Midas Lambrichts <midaslamb@gmail.com>"]
+authors = ["Midas Lambrichts <midaslamb@gmail.com>", "Nikita Patskov <patskovn@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "A simple type for non empty Strings, similar to NonZeroUsize and friends."
-repository = "https://github.com/MidasLamb/non-empty-string"
+repository = "https://github.com/patskovn/non-empty-string.git"
 keywords = ["nonemptystring", "string", "str", "non-empty", "nonempty"]
 
 [package.metadata."docs.rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1", features = ["derive"] }
 
 [features]
 default = []
+macro = []
 serde = ["dep:serde"]
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ use delegate::delegate;
 #[cfg(feature = "serde")]
 mod serde_support;
 
+#[cfg(feature = "macro")]
+mod macros;
+
 mod trait_impls;
 
 /// A simple String wrapper type, similar to NonZeroUsize and friends.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,44 @@
+#[macro_export]
+/// Creates a `NonEmptyString` from a string literal at compile time.
+///
+/// This macro ensures that the provided string is **not empty** at compile time,
+/// preventing runtime errors due to empty strings.
+///
+/// # Examples
+///
+/// ```
+/// use non_empty_string::{non_empty, NonEmptyString};
+///
+/// let s: NonEmptyString = non_empty!("Hello, Rust!");
+/// assert_eq!(s, NonEmptyString::new("Hello, Rust!".to_string()).unwrap());
+/// ```
+///
+/// # Compile-time Failure
+///
+/// If an empty string is provided, this macro will cause a **compile-time error**.
+///
+/// ```compile_fail
+/// use non_empty_string::non_empty;
+///
+/// let s = non_empty!("");
+/// ```
+macro_rules! non_empty {
+    ($s:expr) => {{
+        // Compile-time assertion to ensure the string is non-empty
+        const _: () = assert!(!$s.is_empty(), "String cannot be empty");
+
+        // Create a NonEmptyString, unsafely wrapping since we've checked it's valid
+        unsafe { NonEmptyString::new_unchecked($s.to_string()) }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::NonEmptyString;
+
+    #[test]
+    fn test_non_empty_string_macro_valid() {
+        let s = non_empty!("Test String");
+        assert_eq!(s, NonEmptyString::try_from("Test String").unwrap());
+    }
+}


### PR DESCRIPTION
This is more convenient for constant strings in the codebase that are known to be non empty.

Proper tests for failures would require importing special libraries for macro tests. I do not expect this to be too so I assume it is better to keep this lib smaller and not to add unit tests for compilation failures. Thankfully doctests validate the behaviour, but to be sure I tested it manually via:

```
diff --git a/src/macros.rs b/src/macros.rs
index a1720fd..0b411cc 100644
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -41,4 +41,9 @@ mod tests {
         let s = non_empty!("Test String");
         assert_eq!(s, NonEmptyString::try_from("Test String").unwrap());
     }
+
+    #[test]
+    fn test_non_empty_string_macro_empty_runtime() {
+        let _ = non_empty!("");
+    }
 }
```

And then
```
$ cargo t --features macro

error[E0080]: evaluation of constant value failed
  --> src/macros.rs:48:17
   |
48 |         let _ = non_empty!("");
   |                 ^^^^^^^^^^^^^^ the evaluated program panicked at 'String cannot be empty', src/macros.rs:48:17
   |
   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `non_empty` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0080`.
error: could not compile `non-empty-string` (lib test) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```